### PR TITLE
Update iconv dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "git://github.com/justinklemm/i18n-strings-files.git"
   },
   "dependencies": {
-    "iconv": "2.1.11"
+    "iconv": "2.2.0"
   },
   "devDependencies": {
     "mocha": "2.4.5",


### PR DESCRIPTION
iconv 2.1.11 does not build with nodejs 6.0.0
